### PR TITLE
Fix error when http module is mock in tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ function getCurrentNodeMethods () {
     return method.toLowerCase()
   });
 
-  return methods;
+  return (methods && methods.length > 0) ? methods : false;
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -27,9 +27,11 @@ module.exports = getCurrentNodeMethods() || getBasicNodeMethods()
  */
 
 function getCurrentNodeMethods () {
-  return http.METHODS && http.METHODS.map(function lowerCaseMethod (method) {
+  const methods = http.METHODS && http.METHODS.map(function lowerCaseMethod (method) {
     return method.toLowerCase()
-  })
+  });
+
+  return methods;
 }
 
 /**


### PR DESCRIPTION
Hello:

 Let me explain to you the problem that I am trying to solve with this PR. The problem I found is that, when I create a mock with the Jest library of Http for my unit tests, the tests fails. The reason is because the module application.js from the express library, which has a dependency on "methods", obtaining an empty array of methods ... and that ends with an exception. The problem comes because, when I make the mock of the http library with Jest, the value of * http.METHODS * is [] which it is evaluated as true and makes the function * getBasicNodeMethods * never run.

My changes are, basically, to check that he http.METHODS array exist and its length is different of 0 so, it that way, the library http can be mock for unit testing.

Regards