### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/test/browserify.js
+++ b/test/browserify.js
@@ -48,7 +48,7 @@ run('when browserified', function () {
 
 function getCoverageGlobal () {
   for (var key in global) {
-    if (key.substr(0, 6) === '$$cov_') {
+    if (key.slice(0, 6) === '$$cov_') {
       return global[key]
     }
   }


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.