### PR TITLE
Add notice for modern Node.js versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ with the following differences:
   * Provides the fallback list when using tools like `browserify` without pulling
     in the `http` shim module.
 
+> [!NOTE]
+> If you only have to support modern versions of Node.js, it is highly recommended to use the built-in [`http.METHODS`](https://nodejs.org/api/http.html#httpmethods) module from Node.js core instead of this module.
+
 ## Install
 
 This is a [Node.js](https://nodejs.org/en/) module available through the


### PR DESCRIPTION
Adds a notice to the README that explains to the user they might not need this module with example code that could replace the module in their project if they are targeting newer versions of Node.js.

See #29 for related discusssion.

![A screenshot of the notice as it would appear in the README](https://github.com/user-attachments/assets/9496af86-cb7a-4554-8cc4-702b145d410f)
